### PR TITLE
Add multiple API key feature support

### DIFF
--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -60,12 +60,12 @@ If both are configured, `apiKey` in `Config.toml` will be overwritten by the env
 Environment variable can be configured for either a single user or multiple users.
 
 For a single user account:
-- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
-- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY>"`
 
 For multiple user accounts:
-- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
-- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
 
 ### Observe Metrics in New Relic
 

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -48,8 +48,24 @@ key1 = "<VALUE_1>"
 key2 = "<VALUE_2>"
 ```
 
+Users can also configure multiple API keys for different New Relic user accounts as given below.
+
+```toml
+[ballerinax.newrelic]
+apiKey=["<NEW_RELIC_LICENSE_KEY_1>", "<NEW_RELIC_LICENSE_KEY_2>"]   # Mandatory Configuration.
+```
+
 User can configure the environment variable `BALLERINA_NEW_RELIC_API_KEY` instead of `apiKey` in `Config.toml`.
 If both are configured, `apiKey` in `Config.toml` will be overwritten by the environment variable value.
+Environment variable can be configured for either a single user or multiple users.
+
+For a single user account:
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
+
+For multiple user accounts:
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
 
 ### Observe Metrics in New Relic
 

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -60,12 +60,12 @@ If both are configured, `apiKey` in `Config.toml` will be overwritten by the env
 Environment variable can be configured for either a single user or multiple users.
 
 For a single user account:
-- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
-- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY>"`
 
 For multiple user accounts:
-- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
-- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY="<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
 
 ### Observe Metrics in New Relic
 

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -24,6 +24,7 @@ observabilityIncluded=true
 ```
 
 To enable the extension and publish traces and metrics to New Relic, add the following to the `Config.toml` when running your program.
+
 ```toml
 [ballerina.observe]
 tracingEnabled=true
@@ -46,5 +47,56 @@ isPayloadLoggingEnabled=false       # Optional Configuration. Default value is f
 key1 = "<VALUE_1>"
 key2 = "<VALUE_2>"
 ```
+
+Users can also configure multiple API keys for different New Relic user accounts as given below.
+
+```toml
+[ballerinax.newrelic]
+apiKey=["<NEW_RELIC_LICENSE_KEY_1>", "<NEW_RELIC_LICENSE_KEY_2>"]   # Mandatory Configuration.
+```
+
 User can configure the environment variable `BALLERINA_NEW_RELIC_API_KEY` instead of `apiKey` in `Config.toml`.
 If both are configured, `apiKey` in `Config.toml` will be overwritten by the environment variable value.
+Environment variable can be configured for either a single user or multiple users.
+
+For a single user account:
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY>"`
+
+For multiple user accounts:
+- Linux/Unix: `export BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+- Windows: `set BALLERINA_NEW_RELIC_API_KEY = "<NEW_RELIC_LICENSE_KEY_1>, <NEW_RELIC_LICENSE_KEY_2>"`
+
+### Observe Metrics in New Relic
+
+Instead of using prometheus as an intermediate metric reporter that remote writes the metrics to New Relic,
+Ballerina New Relic Observability Extension directly publishes metrics to New Relic on the following metric API `https://metric-api.newrelic.com/metric/v1`.
+
+Instrumentation of metrics is done using the [com.newrelic.telemetry](https://github.com/newrelic/newrelic-telemetry-sdk-java).
+
+#### Available Metrics
+
+The exporter provides the following metrics.
+
+|Metric Name|Description|
+|---|---|
+|response_time_seconds_value|Response time of a HTTP request in seconds|
+|response_time_seconds_max|Maximum response time of a HTTP request|
+|response_time_seconds_min|Minimum response time of a HTTP request|
+|response_time_seconds_mean|Average response time of a HTTP request|
+|response_time_seconds_stdDev|Standard deviation of response time of a HTTP request|
+|response_time_seconds|Summary of HTTP request-response times across various time frames and quantiles|
+|response_time_nanoseconds_total_value|Response time of a HTTP request in nano seconds|
+|requests_total_value|Total number of requests|
+|response_errors_total_value|Total number of response errors|
+|inprogress_requests_value|Total number of inprogress requests|
+|kafka_publishers_value|Number of publishers in kafka|
+|kafka_consumers_value|Number of consumers in kafka|
+|kafka_errors_value|Number of errors happened while publishing in kafka|
+
+### Observe Traces in New Relic
+
+Ballerina New Relic Observability Extension directly publishes traces to New Relic on the following trace API `https://otlp.nr-data.net:4317`.
+Traces are published to New Relic on OpenTelemetry format.
+
+Instrumentation of traces is done using the [io.opentelemetry](https://github.com/open-telemetry/opentelemetry-java) and `GRPC` protocol is used send traces.

--- a/ballerina/metrics_reporter.bal
+++ b/ballerina/metrics_reporter.bal
@@ -21,7 +21,7 @@ configurable int metricReporterFlushInterval = 15000;
 configurable int metricReporterClientTimeout = 10000;
 configurable map<string> additionalAttributes = {};
 
-isolated function startMetricsReporter(string apiKey) {
+isolated function startMetricsReporter(string|string[] apiKey) {
     string[] output = externSendMetrics(apiKey, metricReporterFlushInterval, metricReporterClientTimeout, 
         isTraceLoggingEnabled, isPayloadLoggingEnabled, additionalAttributes);
     
@@ -34,7 +34,7 @@ isolated function startMetricsReporter(string apiKey) {
     }
 }
 
-isolated function externSendMetrics(string apiKey, int metricReporterFlushInterval, int metricReporterClientTimeout, 
+isolated function externSendMetrics(string|string[] apiKey, int metricReporterFlushInterval, int metricReporterClientTimeout, 
     boolean isTraceLoggingEnabled, boolean isPayloadLoggingEnabled, map<string> additionalAttributes) returns string[] = @java:Method {
     'class: "io.ballerina.observe.metrics.newrelic.NewRelicMetricsReporter",
     name: "sendMetrics"

--- a/ballerina/observe.bal
+++ b/ballerina/observe.bal
@@ -22,12 +22,12 @@ const REPORTER_NAME = "newrelic";
 const PROVIDER_NAME = "newrelic";
 const NEW_RELIC_API_KEY_ENV = "BALLERINA_NEW_RELIC_API_KEY";
 
-configurable string apiKey = "";
+configurable string|string[] apiKey = "";
 configurable boolean isTraceLoggingEnabled = false;
 configurable boolean isPayloadLoggingEnabled = false;
 
 function init() returns error? {
-    string configurableAPIKey = apiKey;
+    string|string[] configurableAPIKey = apiKey;
 
     if (os:getEnv(NEW_RELIC_API_KEY_ENV) != "") {
         configurableAPIKey = os:getEnv(NEW_RELIC_API_KEY_ENV);

--- a/ballerina/observe.bal
+++ b/ballerina/observe.bal
@@ -17,6 +17,7 @@
 import ballerina/observe;
 import ballerina/os;
 import ballerina/log;
+import ballerina/regex;
 
 const REPORTER_NAME = "newrelic";
 const PROVIDER_NAME = "newrelic";
@@ -30,7 +31,7 @@ function init() returns error? {
     string|string[] configurableAPIKey = apiKey;
 
     if (os:getEnv(NEW_RELIC_API_KEY_ENV) != "") {
-        configurableAPIKey = os:getEnv(NEW_RELIC_API_KEY_ENV);
+        configurableAPIKey = parseStringArray(os:getEnv(NEW_RELIC_API_KEY_ENV));
         log:printInfo("Using New Relic API key from environment variable " + NEW_RELIC_API_KEY_ENV);
     }
 
@@ -44,4 +45,21 @@ function init() returns error? {
             startMetricsReporter(configurableAPIKey);
         }
     }
+}
+
+// Function to parse string array from environment variable
+function parseStringArray(string envValue) returns string[]|string {
+    string[] parts = regex:split(envValue, ",");
+    
+    if (parts.length() == 1) {
+        return string:trim(envValue);
+    }
+
+    string[] result = [];
+    foreach string part in parts {
+        string trimmed = string:trim(part);
+        result.push(trimmed);
+    }
+    
+    return result;
 }

--- a/ballerina/tracer_provider.bal
+++ b/ballerina/tracer_provider.bal
@@ -24,7 +24,7 @@ configurable decimal tracingSamplerParam = 1;
 configurable int tracingReporterFlushInterval = 15000;
 configurable int tracingReporterBufferSize = 10000;
 
-function startTracerProvider(string apiKey) {
+function startTracerProvider(string|string[] apiKey) {
     string selectedSamplerType;
 
     if tracingSamplerType != "const" && tracingSamplerType != "ratelimiting" && tracingSamplerType != "probabilistic" {
@@ -47,7 +47,7 @@ function startTracerProvider(string apiKey) {
     }
 }
 
-function externStartPublishingTraces(string apiKey, string samplerType,
+function externStartPublishingTraces(string|string[] apiKey, string samplerType,
         decimal samplerParam, int reporterFlushInterval, int reporterBufferSize) returns string[] = @java:Method {
     'class: "io.ballerina.observe.trace.newrelic.NewRelicTracerProvider",
     name: "startPublishingTraces"

--- a/native/src/main/java/io/ballerina/observe/metrics/newrelic/NewRelicMetricsReporter.java
+++ b/native/src/main/java/io/ballerina/observe/metrics/newrelic/NewRelicMetricsReporter.java
@@ -167,7 +167,7 @@ public class NewRelicMetricsReporter {
             for (MetricBatchSender sender : senders) {
                 try {
                     Response response = sender.sendBatch(batch);
-                    logger.info("New Relic metric reporter status: " + response.getStatusMessage() + ", response: "
+                    logger.info("New Relic metric reporter status: " + response.getStatusCode() + ", response: "
                             + response.getBody() + ", payload metrics count: " + metricCount);
                 } catch (ResponseException e) {
                     logger.severe("Error sending metrics to New Relic: " + e.getMessage());

--- a/native/src/main/java/io/ballerina/observe/metrics/newrelic/NewRelicMetricsReporter.java
+++ b/native/src/main/java/io/ballerina/observe/metrics/newrelic/NewRelicMetricsReporter.java
@@ -52,6 +52,8 @@ import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,10 +84,30 @@ public class NewRelicMetricsReporter {
         return executor;
     }
 
-    public static BArray sendMetrics(BString apiKey, int metricReporterFlushInterval,
+    public static BArray sendMetrics(Object apiKey, int metricReporterFlushInterval,
                                      int metricReporterClientTimeout, boolean isTraceLoggingEnabled,
                                      boolean isPayloadLoggingEnabled, BMap<BString, BString> additionalAttributes) {
         BArray output = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
+
+        // Handle both string and string[] cases
+        List<String> apiKeyList = new ArrayList<>();
+        if (apiKey instanceof BString) {
+            String apiKeyValue = ((BString) apiKey).getValue();
+            apiKeyList.add(apiKeyValue);
+        } else if (apiKey instanceof BArray) {
+            BArray apiKeyArray = (BArray) apiKey;
+            if (apiKeyArray.size() > 0) {
+                for (String key : apiKeyArray.getStringArray()) {
+                    apiKeyList.add(key);
+                }
+            } else {
+                output.append(StringUtils.fromString("error: empty API key array provided"));
+                return output;
+            }
+        } else {
+            output.append(StringUtils.fromString("error: invalid API key type"));
+            return output;
+        }
 
         if (isTraceLoggingEnabled) {
             logger.setLevel(Level.INFO);
@@ -106,14 +128,18 @@ public class NewRelicMetricsReporter {
 
         MetricBatchSenderFactory factory = MetricBatchSenderFactory.fromHttpImplementation(OkHttpPoster::new);
 
-        SenderConfiguration config = factory
-                .configureWith(apiKey.getValue())
-                .httpPoster(httpPoster)
-                .endpoint(endpointUrl)
-                .auditLoggingEnabled(isTraceLoggingEnabled)
-                .build();
+        List<MetricBatchSender> senders = new ArrayList<>();
+        for (String apiKeyValue : apiKeyList) {
+            SenderConfiguration config = factory
+                    .configureWith(apiKeyValue)
+                    .httpPoster(httpPoster)
+                    .endpoint(endpointUrl)
+                    .auditLoggingEnabled(isTraceLoggingEnabled)
+                    .build();
 
-        MetricBatchSender sender = MetricBatchSender.create(config);
+            MetricBatchSender sender = MetricBatchSender.create(config);
+            senders.add(sender);
+        }
 
         // Create common attributes for all metrics
         Attributes commonAttributes = null;
@@ -138,12 +164,14 @@ public class NewRelicMetricsReporter {
                 logger.info("Metric buffer: " + metricBuffer);
             }
             MetricBatch batch = metricBuffer.createBatch();
-            try {
-                Response response = sender.sendBatch(batch);
-                logger.info("New Relic metric reporter status: " + response.getStatusMessage() + ", response: "
-                        + response.getBody() + ", payload metrics count: " + metricCount);
-            } catch (ResponseException e) {
-                logger.severe("Error sending metrics to New Relic: " + e.getMessage());
+            for (MetricBatchSender sender : senders) {
+                try {
+                    Response response = sender.sendBatch(batch);
+                    logger.info("New Relic metric reporter status: " + response.getStatusMessage() + ", response: "
+                            + response.getBody() + ", payload metrics count: " + metricCount);
+                } catch (ResponseException e) {
+                    logger.severe("Error sending metrics to New Relic: " + e.getMessage());
+                }
             }
         }, SCHEDULE_EXECUTOR_INITIAL_DELAY, metricReporterFlushInterval, TimeUnit.MILLISECONDS);
 

--- a/native/src/main/java/io/ballerina/observe/trace/newrelic/NewRelicTracerProvider.java
+++ b/native/src/main/java/io/ballerina/observe/trace/newrelic/NewRelicTracerProvider.java
@@ -37,6 +37,8 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
@@ -63,21 +65,44 @@ public class NewRelicTracerProvider implements TracerProvider {
         // Do Nothing
     }
 
-    public static BArray startPublishingTraces(BString apiKey, BString samplerType, BDecimal samplerParam,
+    public static BArray startPublishingTraces(Object apiKey, BString samplerType, BDecimal samplerParam,
                                                 int reporterFlushInterval, int reporterBufferSize) {
         BArray output = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
 
-        OtlpGrpcSpanExporter exporter = OtlpGrpcSpanExporter.builder()
-                .setEndpoint(TRACE_REPORTER_ENDPOINT)
-                .addHeader(TRACE_API_KEY_HEADER, apiKey.getValue())
-                .build();
+        // Handle both string and string[] cases
+        List<String> apiKeyList = new ArrayList<>();
+        if (apiKey instanceof BString) {
+            String apiKeyValue = ((BString) apiKey).getValue();
+            apiKeyList.add(apiKeyValue);
+        } else if (apiKey instanceof BArray) {
+            BArray apiKeyArray = (BArray) apiKey;
+            if (apiKeyArray.size() > 0) {
+                for (String key : apiKeyArray.getStringArray()) {
+                    apiKeyList.add(key);
+                }
+            } else {
+                output.append(StringUtils.fromString("error: empty API key array provided"));
+                return output;
+            }
+        } else {
+            output.append(StringUtils.fromString("error: invalid API key type"));
+            return output;
+        }
 
-        tracerProviderBuilder = SdkTracerProvider.builder()
-                .addSpanProcessor(BatchSpanProcessor
-                        .builder(exporter)
-                        .setMaxExportBatchSize(reporterBufferSize)
-                        .setExporterTimeout(reporterFlushInterval, TimeUnit.MILLISECONDS)
-                        .build());
+        tracerProviderBuilder = SdkTracerProvider.builder();
+
+        for (String apiKeyValue : apiKeyList) {
+            OtlpGrpcSpanExporter exporter = OtlpGrpcSpanExporter.builder()
+                    .setEndpoint(TRACE_REPORTER_ENDPOINT)
+                    .addHeader(TRACE_API_KEY_HEADER, apiKeyValue)
+                    .build();
+
+            tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor
+                    .builder(exporter)
+                    .setMaxExportBatchSize(reporterBufferSize)
+                    .setExporterTimeout(reporterFlushInterval, TimeUnit.MILLISECONDS)
+                    .build());
+        }
 
         tracerProviderBuilder.setSampler(selectSampler(samplerType, samplerParam));
         output.append(StringUtils.fromString("ballerina: started publishing traces to New Relic on " +

--- a/native/src/main/java/io/ballerina/observe/trace/newrelic/NewRelicTracerProvider.java
+++ b/native/src/main/java/io/ballerina/observe/trace/newrelic/NewRelicTracerProvider.java
@@ -132,7 +132,7 @@ public class NewRelicTracerProvider implements TracerProvider {
 
         return tracerProviderBuilder.setResource(
                         Resource.create(Attributes.of(SERVICE_NAME, serviceName)))
-                .build().get("newrelic");
+                .build().get(TRACER_NAME);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Currently Ballerina publishes observability data (metrics and traces) to New Relic server via ballerinax/newrelic extension. User need to configure the API KEY for the specific New Relic account.

This will provide the configuration to publish data to multiple New Relic accounts as they need to publish data to multiple accounts.

Fixes https://github.com/wso2-enterprise/wso2-integration-internal/issues/2255

## Approach
Users can configure API keys for multiple accounts as given below.

```toml
[ballerinax.newrelic]
apiKey = ["<API_KEY_1>", "<API_KEY_2>", "<API_KEY_3>"]
```

Users can also define a single API key as given below.

```toml
[ballerinax.newrelic]
apiKey = "<API_KEY>"
```

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.